### PR TITLE
Use monitor API rather than obsolete log downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+preservica-config.json

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ This command take no input or parameters, but is dependent on an internal variab
 
 The script will add (or replace) the element of `islandora:preservicaExportDate` to the RELS-EXT with the datetime value of the export time per the Bag's file properties.
 
+## preservica-get-log.py
+A script to read Preservica OPEX ingest logs from the API, and ouput a CSV of the sourceId and the entityRef, to be used in `preservica-mark-ingested.sh`
+
 ## preservica-mark-ingested.sh
-A script to examine a download of a Process (Ingest Card) from the Preserica Monitor Processes interface, and then update the associated Islandora object's RELS-EXT datastream with a reference to the Preservica asset Ref.
+A script to examine a download of Preservica logs, and then update the associated Islandora object's RELS-EXT datastream with a reference to the Preservica asset Ref.
 
 This command takes a single argument of the path to the downloaded file.
 

--- a/preservica-get-log.py
+++ b/preservica-get-log.py
@@ -1,0 +1,113 @@
+import requests
+import time
+import csv
+import sys
+import json
+from urllib.parse import urljoin
+
+'''
+Copilot prompt:
+Create a python script which, given a configuration file, queries a RESTful API to authenticate, then fetches paginated JSON responses to ultimately write out a CSV file.  The configuration file will include a username, password, and a base URL for the API endpoints.  The authentication endpoint is at "/api/accesstoken/login".  Provide an Accept header of "application/json", and POST the username and password as form urlencoded fields of username and password.  Check the JSON response for values of "success" (boolean), "token" (string), "refresh-token" (string), and "validFor" (integer, in minutes).  Use the token as the value for the header "Preservica-Access-Token" in subsequent requests, until it expires.  If expiry is less than 1 minute away, POST the "refresh-token" to the endpoint "/api/accesstoken/refresh", using the "Preservica-Access-Token" header, and reading a new "success" (boolean), "token" (string), "refresh-token" (string), and "validFor" (integer, in minutes).  For the paginated iteration, use the "Preservica-Access-Token" and "Accept: application/json;charset=UTF-8" in the headers for GET requests against the endpoint "/api/processmonitor/monitors" with querystring values of "status=Succeeded&category=Ingest&subcategory=OPEX".  Examine the JSON response for a value of "success" (boolean).  When success is true, examine the "value" key for a "paging" key which will contain a "totalResults" value (integer).  When pagination is needed, the "paging" key will also contain a "next" value with a URL to the subsequent page.  In the "value" key, a key called "monitors" will be an array of objects.  Each object will have a keys of "mappedId" (string) and "name" (string).  When "name" begins with "islandora", add the "mappedId" to an array which will be used in a separated paged call.  Harvest all "mappedId" values to that array, paginating and refreshing tokens as needed.  When the array is complete, use each "mappedId" as input to a GET request to the "/api/processmonitor/messages" endpoint.  Use the "Preservica-Access-Token" and "Accept: application/json;charset=UTF-8" headers, and supply the "mappedId" as the value of a "monitor" querystring parameter.  Also supply querystring parameters of "status=Info".  Again, examine the JSON response for a value of "success" (boolean).  When success is true, examine the "value" key for a "paging" key which will contain a "totalResults" value (integer).  When pagination is needed, the "paging" key will also contain a "next" value with a URL to the subsequent page.  In the "value" key, a key called "messages" will be an array of objects.  When the object in "messages" has a "sourceId" key which begins with "pitt:", write the value of the object's "sourceId" and "entityRef" values to STDOUT in CSV format.  Continue until pagination is exhausted.
+'''
+
+CONFIG_FILE = "preservica-config.json"  # Example: {"username": "...", "password": "...", "base_url": "https://example.com"}
+
+# Load configuration
+with open(CONFIG_FILE, "r") as f:
+    config = json.load(f)
+
+USERNAME = config["username"]
+PASSWORD = config["password"]
+BASE_URL = config["base_url"]
+
+AUTH_ENDPOINT = "/api/accesstoken/login"
+REFRESH_ENDPOINT = "/api/acesstoken/refresh"
+MONITORS_ENDPOINT = "/api/processmonitor/monitors"
+MESSAGES_ENDPOINT = "/api/processmonitor/messages"
+
+# Globals for token management
+token = None
+refresh_token = None
+expiry_time = None  # epoch timestamp when token expires
+
+def authenticate():
+    global token, refresh_token, expiry_time
+    url = urljoin(BASE_URL, AUTH_ENDPOINT)
+    headers = {"Accept": "application/json"}
+    data = {"username": USERNAME, "password": PASSWORD}
+    resp = requests.post(url, headers=headers, data=data)
+    resp.raise_for_status()
+    result = resp.json()
+    if not result.get("success"):
+        raise Exception("Authentication failed")
+    token = result["token"]
+    refresh_token = result["refresh-token"]
+    expiry_time = time.time() + (result["validFor"] * 60)
+
+def refresh():
+    global token, refresh_token, expiry_time
+    url = urljoin(BASE_URL, REFRESH_ENDPOINT)
+    headers = {
+        "Accept": "application/json",
+        "Preservica-Access-Token": token
+    }
+    data = {"refresh-token": refresh_token}
+    resp = requests.post(url, headers=headers, data=data)
+    resp.raise_for_status()
+    result = resp.json()
+    if not result.get("success"):
+        raise Exception("Token refresh failed")
+    token = result["token"]
+    refresh_token = result["refresh-token"]
+    expiry_time = time.time() + (result["validFor"] * 60)
+
+def ensure_token_valid():
+    if expiry_time - time.time() < 60:  # less than 1 minute left
+        refresh()
+
+def get_headers():
+    ensure_token_valid()
+    return {
+        "Accept": "application/json;charset=UTF-8",
+        "Preservica-Access-Token": token
+    }
+
+def fetch_paginated(url):
+    """Fetch paginated results from given URL, yielding JSON 'value' objects."""
+    while url:
+        ensure_token_valid()
+        resp = requests.get(url, headers=get_headers())
+        resp.raise_for_status()
+        data = resp.json()
+        if not data.get("success"):
+            break
+        value = data.get("value", {})
+        yield value
+        paging = value.get("paging", {})
+        url = paging.get("next")
+
+def main():
+    authenticate()
+
+    # Step 1: Collect mappedIds from monitors
+    monitors_url = urljoin(BASE_URL, MONITORS_ENDPOINT) + "?status=Succeeded&category=Ingest&subcategory=OPEX"
+    mapped_ids = []
+    for value in fetch_paginated(monitors_url):
+        for monitor in value.get("monitors", []):
+            if monitor.get("name", "").startswith("islandora"):
+                mapped_ids.append(monitor["mappedId"])
+
+    # Step 2: For each mappedId, fetch messages and output CSV
+    writer = csv.writer(sys.stdout)
+    writer.writerow(["sourceId", "entityRef"])
+    for mid in mapped_ids:
+        messages_url = urljoin(BASE_URL, MESSAGES_ENDPOINT) + f"?monitor={mid}&status=Info"
+        for value in fetch_paginated(messages_url):
+            for msg in value.get("messages", []):
+                source_id = msg.get("sourceId", "")
+                if source_id.startswith("pitt:"):
+                    writer.writerow([source_id, msg.get("entityRef", "")])
+
+if __name__ == "__main__":
+    main()
+

--- a/preservica-get-log.py
+++ b/preservica-get-log.py
@@ -46,13 +46,12 @@ def authenticate():
 
 def refresh():
     global token, refresh_token, expiry_time
-    url = urljoin(BASE_URL, REFRESH_ENDPOINT)
+    url = urljoin(BASE_URL, REFRESH_ENDPOINT) + f"?refreshToken={refresh_token}"
     headers = {
         "Accept": "application/json",
         "Preservica-Access-Token": token
     }
-    data = {"refresh-token": refresh_token}
-    resp = requests.post(url, headers=headers, data=data)
+    resp = requests.post(url, headers=headers)
     resp.raise_for_status()
     result = resp.json()
     if not result.get("success"):
@@ -75,7 +74,6 @@ def get_headers():
 def fetch_paginated(url):
     """Fetch paginated results from given URL, yielding JSON 'value' objects."""
     while url:
-        ensure_token_valid()
         resp = requests.get(url, headers=get_headers())
         resp.raise_for_status()
         data = resp.json()

--- a/preservica-mark-ingested.sh
+++ b/preservica-mark-ingested.sh
@@ -54,7 +54,7 @@ do
     >&2 echo "xsltproc failed on $i"
     ERRORFLAG=1
   fi 
-done < $1
+done < $MESSAGEFILE
 # Ensure no errors were caught before continuing
 if [[ "$ERRORFLAG" = "" ]]
 then

--- a/preservica-mark-ingested.sh
+++ b/preservica-mark-ingested.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Where is the ingest monitor message file downloaded from Preservica?
+# Where is the downloaded API log from Preservica?
 MESSAGEFILE=$1
 if [ "$MESSAGEFILE" == "" ]
 then
@@ -46,7 +46,7 @@ do
     continue
   fi
   i=$TMPDIR/rels-ext/`echo $line | cut -d',' -f1`^RELS-EXT.rdf
-  PREF=`echo $line | cut -d',' -f2`
+  PREF=`echo $line | cut -d',' -f2 | tr -d '\n' | tr -d '\r'`
   # Transform the RELS-EXT with our XSLT, adding in the new presericaExportDate
   xsltproc --stringparam pref "$PREF" -o $i $TMPDIR/update-preservica-ingest.xsl $i
   if [[ $? -ne 0 ]]

--- a/preservica-mark-ingested.sh
+++ b/preservica-mark-ingested.sh
@@ -28,19 +28,8 @@ cat <<'EOF'> $TMPDIR/update-preservica-ingest.xsl
   </xsl:template>
 </xsl:stylesheet>
 EOF
-# Use a python script to extract the fifth (islandora identifier) and sixth (preservica identifier) columns from the CSV
-cat <<'EOF'> $TMPDIR/extract-identifiers.py
-import sys
-import csv
-with open(sys.argv[1], 'r') as csvfile:
-  linereader = csv.reader(csvfile)
-  for line in linereader:
-    if line[4].startswith('pitt:'):
-      print(line[4] + '|' + line[5])
-EOF
-python $TMPDIR/extract-identifiers.py $MESSAGEFILE > $TMPDIR/id-pairs.pipe
 # Extract just the PIDs
-cut -d'|' -f1 $TMPDIR/id-pairs.pipe > $TMPDIR/dsio.pids
+cut -d',' -f1 $1 | grep '^pitt:' > $TMPDIR/dsio.pids
 mkdir $TMPDIR/rels-ext
 # Fetch the RELS-EXT for each PID in the list
 drush -qy --root=/var/www/html/drupal7/ --user=$USER --uri=http://gamera.library.pitt.edu islandora_datastream_crud_fetch_datastreams --pid_file=$TMPDIR/dsio.pids --dsid=RELS-EXT --datastreams_directory=$TMPDIR/rels-ext --filename_separator=^
@@ -52,8 +41,12 @@ fi
 # Iterate across each PID
 while read -r line
 do
-  i=$TMPDIR/rels-ext/`echo $line | cut -d'|' -f1`^RELS-EXT.rdf
-  PREF=`echo $line | cut -d'|' -f2`
+  if [[ $line != "pitt:"* ]]
+  then
+    continue
+  fi
+  i=$TMPDIR/rels-ext/`echo $line | cut -d',' -f1`^RELS-EXT.rdf
+  PREF=`echo $line | cut -d',' -f2`
   # Transform the RELS-EXT with our XSLT, adding in the new presericaExportDate
   xsltproc --stringparam pref "$PREF" -o $i $TMPDIR/update-preservica-ingest.xsl $i
   if [[ $? -ne 0 ]]
@@ -61,7 +54,7 @@ do
     >&2 echo "xsltproc failed on $i"
     ERRORFLAG=1
   fi 
-done < $TMPDIR/id-pairs.pipe
+done < $1
 # Ensure no errors were caught before continuing
 if [[ "$ERRORFLAG" = "" ]]
 then


### PR DESCRIPTION
Manual log downloads for Preservica have changed to no longer have the `sourceId` or `entityRef`.  Fetch these from the API instead.