### PR TITLE
Change mark/unmark scripts to use output from preservica api rather than legacy log file format

### DIFF
--- a/preservica-mark-ingested.sh
+++ b/preservica-mark-ingested.sh
@@ -29,7 +29,7 @@ cat <<'EOF'> $TMPDIR/update-preservica-ingest.xsl
 </xsl:stylesheet>
 EOF
 # Extract just the PIDs
-cut -d',' -f1 $1 | grep '^pitt:' > $TMPDIR/dsio.pids
+cut -d',' -f1 $MESSAGEFILE | grep '^pitt:' > $TMPDIR/dsio.pids
 mkdir $TMPDIR/rels-ext
 # Fetch the RELS-EXT for each PID in the list
 drush -qy --root=/var/www/html/drupal7/ --user=$USER --uri=http://gamera.library.pitt.edu islandora_datastream_crud_fetch_datastreams --pid_file=$TMPDIR/dsio.pids --dsid=RELS-EXT --datastreams_directory=$TMPDIR/rels-ext --filename_separator=^

--- a/preservica-unmarked-ingested.sh
+++ b/preservica-unmarked-ingested.sh
@@ -27,20 +27,8 @@ cat <<'EOF'> $TMPDIR/undo-preservica-ingest.xsl
 </xsl:stylesheet>
 EOF
 
-# Use a python script to extract the fifth (islandora identifier) and sixth (preservica identifier) columns from the CSV
-cat <<'EOF'> $TMPDIR/extract-identifiers.py
-import sys
-import csv
-with open(sys.argv[1], 'r') as csvfile:
-  linereader = csv.reader(csvfile)
-  for line in linereader:
-    if line[4].startswith('pitt:'):
-      print(line[4] + '|' + line[5])
-EOF
-python $TMPDIR/extract-identifiers.py $MESSAGEFILE > $TMPDIR/id-pairs.pipe
-
 # Extract just the PIDs
-cut -d'|' -f1 $TMPDIR/id-pairs.pipe > $TMPDIR/dsio.pids
+cut -d',' -f1 $MESSAGEFILE > $TMPDIR/dsio.pids
 mkdir $TMPDIR/rels-ext
 
 # Fetch the RELS-EXT for each PID in the list
@@ -54,7 +42,7 @@ fi
 # Iterate across each PID
 while read -r line
 do
-  i=$TMPDIR/rels-ext/`echo $line | cut -d'|' -f1`^RELS-EXT.rdf
+  i=$TMPDIR/rels-ext/`echo $line | cut -d',' -f1`^RELS-EXT.rdf
   
   # Transform the RELS-EXT with our XSLT, removing the preservicaRef and restoring preservicaExportDate
   xsltproc -o $i $TMPDIR/undo-preservica-ingest.xsl $i
@@ -64,7 +52,7 @@ do
     >&2 echo "xsltproc failed on $i"
     ERRORFLAG=1
   fi 
-done < $TMPDIR/id-pairs.pipe
+done < $MESSAGEFILE
 
 # Ensure no errors were caught before continuing
 if [[ "$ERRORFLAG" = "" ]]


### PR DESCRIPTION
[preservica-get-log.py](https://github.com/ulsdevteam/islandoraPreservicaExport?tab=readme-ov-file#preservica-get-logpy) will return a CSV of sourceId and entityRef, so no extra processing is needed.  Just use it as a CSV rather than pipe-delimited file.